### PR TITLE
Face encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ scripts/.idea*
 rt_gene/model_nets/Model_allsubjects1.h5
 rt_gene/model_nets/dnn_deploy.prototxt
 rt_gene/model_nets/res10_300x300_ssd_iter_140000.caffemodel
+rt_gene/model_nets/dlib_face_recognition_resnet_model_v1.dat
 
 *~
 # Byte-compiled / optimized / DLL files

--- a/rt_gene/CMakeLists.txt
+++ b/rt_gene/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
   uvc_camera
   dynamic_reconfigure
-  dlib
 )
 
 ## System dependencies are found with CMake's conventions
@@ -31,14 +30,14 @@ catkin_download(
     REQUIRED
 )
 
-#catkin_download(
-#    dlib_face_recognition_resnet_model_v1.dat
-#    https://insert.correct.url/here
-#    DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/model_nets
-#    FILENAME dlib_face_recognition_resnet_model_v1.dat
-#    MD5 2316b25ae80acf4ad9b620b00071c423
-#    REQUIRED
-#)
+catkin_download(
+    dlib_face_recognition_resnet_model_v1.dat
+    https://imperialcollegelondon.box.com/shared/static/7zfltrwhrss0zsq2d2z0mgbz4j3ij3fk.dat
+    DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/model_nets
+    FILENAME dlib_face_recognition_resnet_model_v1.dat
+    MD5 2316b25ae80acf4ad9b620b00071c423
+    REQUIRED
+)
 
 
 

--- a/rt_gene/CMakeLists.txt
+++ b/rt_gene/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
   uvc_camera
   dynamic_reconfigure
+  dlib
 )
 
 ## System dependencies are found with CMake's conventions
@@ -29,6 +30,17 @@ catkin_download(
     MD5 e55ea59d494d66dd075bf1503a32f99c
     REQUIRED
 )
+
+#catkin_download(
+#    dlib_face_recognition_resnet_model_v1.dat
+#    https://insert.correct.url/here
+#    DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/model_nets
+#    FILENAME dlib_face_recognition_resnet_model_v1.dat
+#    MD5 2316b25ae80acf4ad9b620b00071c423
+#    REQUIRED
+#)
+
+
 
 add_custom_target(download ALL DEPENDS download_extra_data)
 

--- a/rt_gene/launch/estimate_gaze.launch
+++ b/rt_gene/launch/estimate_gaze.launch
@@ -26,7 +26,7 @@
       <node pkg="rt_gene" type="extract_landmarks_node.py" name="extract_landmarks_new" output="screen">
           <param name="device_id_facedetection"  value="$(arg device_id_facedetection)" />
           <param name="device_id_facealignment"  value="$(arg device_id_facealignment)" />
-          <param name="face_encoding_tracker" value="True" />
+          <param name="use_face_encoding_tracker" value="False" />
           <param name="rgb_frame_id" value="$(arg rgb_frame_id)" />
           <param name="rgb_frame_id_ros" value="$(arg rgb_frame_id_ros)" />
           <param name="tf_prefix" value="$(arg tf_prefix)" />

--- a/rt_gene/launch/estimate_gaze.launch
+++ b/rt_gene/launch/estimate_gaze.launch
@@ -1,4 +1,5 @@
 <launch>
+    <arg name="use_face_encoding_tracker" default="False" />
     <arg name="interpupillary_distance" default="0.058"/>
     <arg name="start_rviz" default="False"/>
 
@@ -26,7 +27,7 @@
       <node pkg="rt_gene" type="extract_landmarks_node.py" name="extract_landmarks_new" output="screen">
           <param name="device_id_facedetection"  value="$(arg device_id_facedetection)" />
           <param name="device_id_facealignment"  value="$(arg device_id_facealignment)" />
-          <param name="use_face_encoding_tracker" value="False" />
+          <param name="use_face_encoding_tracker" value="$(arg use_face_encoding_tracker)" />
           <param name="rgb_frame_id" value="$(arg rgb_frame_id)" />
           <param name="rgb_frame_id_ros" value="$(arg rgb_frame_id_ros)" />
           <param name="tf_prefix" value="$(arg tf_prefix)" />

--- a/rt_gene/launch/estimate_gaze.launch
+++ b/rt_gene/launch/estimate_gaze.launch
@@ -25,7 +25,8 @@
 
       <node pkg="rt_gene" type="extract_landmarks_node.py" name="extract_landmarks_new" output="screen">
           <param name="device_id_facedetection"  value="$(arg device_id_facedetection)" />
-          <param name="device_id_facealignment"  value="$(arg device_id_facealignment)" /> 
+          <param name="device_id_facealignment"  value="$(arg device_id_facealignment)" />
+          <param name="face_encoding_tracker" value="True" />
           <param name="rgb_frame_id" value="$(arg rgb_frame_id)" />
           <param name="rgb_frame_id_ros" value="$(arg rgb_frame_id_ros)" />
           <param name="tf_prefix" value="$(arg tf_prefix)" />

--- a/rt_gene/package.xml
+++ b/rt_gene/package.xml
@@ -38,12 +38,12 @@
   <depend>image_transport</depend>
   <depend>tf</depend>
   <depend>tf_conversions</depend>
-  <depend>camera_info_manager_py</depend>
+  <!--depend>camera_info_manager_py</depend-->
   <depend>uvc_camera</depend>
   <depend>dynamic_reconfigure</depend>
-  <depend>opencv3</depend>
-  <depend>dlib</depend>
 
+  <depend>python-opencv</depend>
+  <depend>python-dlib</depend>
   <depend>python-scipy</depend>
   <depend>python-numpy</depend>
   <depend>python-tensorflow-gpu-pip</depend>

--- a/rt_gene/package.xml
+++ b/rt_gene/package.xml
@@ -42,6 +42,7 @@
   <depend>uvc_camera</depend>
   <depend>dynamic_reconfigure</depend>
   <depend>opencv3</depend>
+  <depend>dlib</depend>
 
   <depend>python-scipy</depend>
   <depend>python-numpy</depend>

--- a/rt_gene/src/rt_gene/FaceEncodingTracker.py
+++ b/rt_gene/src/rt_gene/FaceEncodingTracker.py
@@ -1,5 +1,6 @@
 """
 @Kevin Cortacero <cortacero.k31130@gmail.com>
+@Ahmed Al-Hindawi <a.al-hindawi@imperial.ac.uk>
 Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode)
 """
 from __future__ import print_function

--- a/rt_gene/src/rt_gene/FaceEncodingTracker.py
+++ b/rt_gene/src/rt_gene/FaceEncodingTracker.py
@@ -81,7 +81,7 @@ class FaceEncodingTracker(GenericTracker):
         # encode the new array
         found_previous = False
 
-        encoding = np.array(element.encode(self.__encode_subject(element)))
+        encoding = np.array(self.__encode_subject(element))
         # check to see if we've seen it before
         for i, previous_encoding in enumerate(self.__removed_elements.keys()):
             previous_encoding = np.fromstring(previous_encoding[1:-1], dtype=np.float, sep=",")

--- a/rt_gene/src/rt_gene/FaceEncodingTracker.py
+++ b/rt_gene/src/rt_gene/FaceEncodingTracker.py
@@ -1,0 +1,112 @@
+"""
+@Kevin Cortacero <cortacero.k31130@gmail.com>
+Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode)
+"""
+from __future__ import print_function
+import numpy as np
+import scipy.optimize
+from GenericTracker import GenericTracker, TrackedElement
+
+
+class FaceEncodingTracker(GenericTracker):
+    def __init__(self):
+        self.__tracked_elements = {}
+        self.__removed_elements = {}
+        self.__i = -1
+        self.__threshold = 0.6
+
+    ''' --------------------------------------------------------------------'''
+    ''' PRIVATE METHODS '''
+
+    def __add_new_element(self, element):
+        # encode the new array
+        found_previous = False
+
+        encoding = np.array(element.encode())
+        # check to see if we've seen it before
+        for i, previous_encoding in enumerate(self.__removed_elements.keys()):
+            previous_encoding = np.fromstring(previous_encoding[1:-1], dtype=np.float, sep=",")
+            distance = np.linalg.norm(previous_encoding - encoding, axis=0)
+
+            # the new element and the previous encoding are the same person
+            if distance < self.__threshold:
+                previous_id = self.__removed_elements.values()[i]
+                self.__tracked_elements[previous_id] = element
+                found_previous = True
+                break
+
+        if not found_previous:
+            self.__tracked_elements[self._generate_new_id()] = element
+
+    def __update_element(self, element_id, element):
+        self.__tracked_elements[element_id] = element
+
+    ''' --------------------------------------------------------------------'''
+    ''' PROTECTED METHODS '''
+
+    # (can be overridden if necessary)
+    def _generate_new_id(self):
+        self.__i += 1
+        return self.__i
+
+    ''' --------------------------------------------------------------------'''
+    ''' PUBLIC METHODS '''
+
+    def get_tracked_elements(self):
+        return self.__tracked_elements
+
+    def clear_elements(self):
+        self.__tracked_elements.clear()
+
+    def track(self, new_elements):
+        # if no new elements, remove old elements
+        if not new_elements:
+            self.clear_elements()
+            return
+
+        # if no elements yet, just add all the new ones
+        if not self.__tracked_elements:
+            [self.__add_new_element(e) for e in new_elements]
+            return
+
+        current_tracked_element_ids = self.__tracked_elements.keys()
+        updated_tracked_element_ids = []
+        map_index_to_id = {}  # map the matrix indexes with real unique id
+
+        distance_matrix = np.ones((len(self.__tracked_elements), len(new_elements)))
+        for i, element_id in enumerate(self.__tracked_elements.keys()):
+            map_index_to_id[i] = element_id
+            for j, new_element in enumerate(new_elements):
+                # ensure new_element is of type TrackedElement upon entry
+                if not isinstance(new_element, TrackedElement):
+                    raise TypeError("Inappropriate type: {} for element whereas a TrackedElement is expected".format(
+                        type(new_element)))
+                distance_matrix[i][j] = self.__tracked_elements[element_id].compute_distance(new_element)
+
+        # get best matching pairs with Hungarian Algorithm
+        col, row = scipy.optimize.linear_sum_assignment(distance_matrix)
+
+        # assign each new element to existing one or store it as new
+        for j, new_element in enumerate(new_elements):
+            try:
+                # find the index of the column matching
+                match_idx = col[np.min(np.nonzero(row == j))]
+                # if the new element matches with existing old one
+                matched_element_id = map_index_to_id[match_idx]
+                self.__update_element(matched_element_id, new_element)
+                updated_tracked_element_ids.append(matched_element_id)
+            except ValueError:
+                # if the new element is not matching
+                self.__add_new_element(new_element)
+
+        # store non-tracked elements in-case they reappear
+        elements_to_delete = list(set(current_tracked_element_ids) - set(updated_tracked_element_ids))
+        for i in elements_to_delete:
+            _element = self.__tracked_elements[i]  # the subject itself
+            encoding = np.array2string(np.array(_element.encode()), formatter={'float_kind': lambda x: "%.5f" % x},
+                                       separator=",")
+            # store the encoding and it's respective key
+            self.__removed_elements[encoding] = i
+
+            # don't track it anymore
+            del self.__tracked_elements[i]

--- a/rt_gene/src/rt_gene/GenericTracker.py
+++ b/rt_gene/src/rt_gene/GenericTracker.py
@@ -8,9 +8,6 @@ from __future__ import print_function
 
 class TrackedElement(object):
 
-    def encode(self):
-        raise NotImplementedError("'encode' method must be overridden!")
-
     def compute_distance(self, other_element):
         raise NotImplementedError("'compute_distance' method must be overridden!")
 

--- a/rt_gene/src/rt_gene/GenericTracker.py
+++ b/rt_gene/src/rt_gene/GenericTracker.py
@@ -1,0 +1,27 @@
+"""
+@Kevin Cortacero <cortacero.k31130@gmail.com>
+@Ahmed Al-Hindawi <a.al-hindawi@imperial.ac.uk>
+Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode)
+"""
+from __future__ import print_function
+
+
+class TrackedElement(object):
+
+    def encode(self):
+        raise NotImplementedError("'encode' method must be overridden!")
+
+    def compute_distance(self, other_element):
+        raise NotImplementedError("'compute_distance' method must be overridden!")
+
+
+class GenericTracker(object):
+
+    def get_tracked_elements(self):
+        raise NotImplementedError("'compute_distance' method must be overridden!")
+
+    def clear_elements(self):
+        raise NotImplementedError("'compute_distance' method must be overridden!")
+
+    def track(self, new_elements):
+        raise NotImplementedError("'compute_distance' method must be overridden!")

--- a/rt_gene/src/rt_gene/SequentialTracker.py
+++ b/rt_gene/src/rt_gene/SequentialTracker.py
@@ -2,49 +2,21 @@
 @Kevin Cortacero <cortacero.k31130@gmail.com>
 Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode)
 """
-from __future__ import print_function
 import numpy as np
-import scipy.optimize
+import scipy
+from GenericTracker import TrackedElement, GenericTracker
 
 
-class TrackedElement(object):
-
-    def encode(self):
-        raise NotImplementedError("'encode' method must be overridden!")
-
-    def compute_distance(self, other_element):
-        raise NotImplementedError("'compute_distance' method must be overridden!")
-
-
-class GenericTracker(object):
+class SequentialTracker(GenericTracker):
     def __init__(self):
         self.__tracked_elements = {}
-        self.__removed_elements = {}
         self.__i = -1
-        self.__threshold = 0.6
 
     ''' --------------------------------------------------------------------'''
     ''' PRIVATE METHODS '''
 
     def __add_new_element(self, element):
-        # encode the new array
-        encoding = np.array(element.encode())
-        found_previous = False
-
-        # check to see if we've seen it before
-        for i, previous_encoding in enumerate(self.__removed_elements.keys()):
-            previous_encoding = np.fromstring(previous_encoding[1:-1], dtype=np.float, sep=",")
-            distance = np.linalg.norm(previous_encoding - encoding, axis=0)
-
-            # the new element and the previous encoding are the same person
-            if distance < self.__threshold:
-                previous_id = self.__removed_elements.values()[i]
-                self.__tracked_elements[previous_id] = element
-                found_previous = True
-                break
-
-        if not found_previous:
-            self.__tracked_elements[self._generate_new_id()] = element
+        self.__tracked_elements[self._generate_unique_id()] = element
 
     def __update_element(self, element_id, element):
         self.__tracked_elements[element_id] = element
@@ -53,7 +25,7 @@ class GenericTracker(object):
     ''' PROTECTED METHODS '''
 
     # (can be overridden if necessary)
-    def _generate_new_id(self):
+    def _generate_unique_id(self):
         self.__i += 1
         return self.__i
 
@@ -97,8 +69,7 @@ class GenericTracker(object):
         # assign each new element to existing one or store it as new
         for j, new_element in enumerate(new_elements):
             try:
-                # find the index of the column matching
-                match_idx = col[np.min(np.nonzero(row == j))]
+                match_idx = col[row.tolist().index(j)]
                 # if the new element matches with existing old one
                 matched_element_id = map_index_to_id[match_idx]
                 self.__update_element(matched_element_id, new_element)
@@ -107,14 +78,7 @@ class GenericTracker(object):
                 # if the new element is not matching
                 self.__add_new_element(new_element)
 
-        # store non-tracked elements in-case they reappear
+        # delete all the non-updated elements
         elements_to_delete = list(set(current_tracked_element_ids) - set(updated_tracked_element_ids))
         for i in elements_to_delete:
-            _element = self.__tracked_elements[i]  # the subject itself
-            encoding = np.array2string(np.array(_element.encode()), formatter={'float_kind': lambda x: "%.5f" % x},
-                                       separator=",")
-            # store the encoding and it's respective key
-            self.__removed_elements[encoding] = i
-
-            # don't track it anymore
             del self.__tracked_elements[i]

--- a/rt_gene/src/rt_gene/extract_landmarks_method.py
+++ b/rt_gene/src/rt_gene/extract_landmarks_method.py
@@ -445,8 +445,7 @@ class LandmarkMethod(object):
         for facebox, landmarks, face_image in zip(faceboxes, all_landmarks, face_images):
             np_landmarks = np.array(landmarks)
             transformed_landmarks = LandmarkMethod.transform_landmarks(np_landmarks, facebox)
-            subject = TrackedSubject(np.array(facebox), face_image, transformed_landmarks, np_landmarks,
-                                     self.face_encoder)
+            subject = TrackedSubject(np.array(facebox), face_image, transformed_landmarks, np_landmarks)
             tracked_subjects.append(subject)
 
         # track the new faceboxes according to the previous ones

--- a/rt_gene/src/rt_gene/extract_landmarks_method.py
+++ b/rt_gene/src/rt_gene/extract_landmarks_method.py
@@ -34,7 +34,9 @@ from rt_gene.kalman_stabilizer import Stabilizer
 from rt_gene.msg import MSG_SubjectImagesList
 from rt_gene.cfg import ModelSizeConfig
 from rt_gene.subject_ros_bridge import SubjectListBridge
-from rt_gene.tracker import GenericTracker, TrackedElement
+from rt_gene.GenericTracker import TrackedElement
+from rt_gene.FaceEncodingTracker import FaceEncodingTracker
+from rt_gene.SequentialTracker import SequentialTracker
 
 import face_alignment
 from face_alignment.detection.sfd import FaceDetector
@@ -114,7 +116,8 @@ class TrackedSubject(TrackedElement):
 
 class LandmarkMethod(object):
     def __init__(self, img_proc=None):
-        self.subject_tracker = GenericTracker()
+        face_encoding_tracker = rospy.get_param("~face_encoding_tracker", default=False)
+        self.subject_tracker = FaceEncodingTracker() if face_encoding_tracker else SequentialTracker()
         self.bridge = CvBridge()
         self.__subject_bridge = SubjectListBridge()
         self.model_size_rescale = 30.0
@@ -176,7 +179,7 @@ class LandmarkMethod(object):
                                                                device=self.device_id_facealignment, flip_input=False)
 
         self.face_encoder = dlib.face_recognition_model_v1(
-            rospkg.RosPack().get_path('rt_gene') + '/model_nets/dlib_face_recognition_resnet_model_v1.dat')
+            rospkg.RosPack().get_path('rt_gene') + '/model_nets/dlib_face_recognition_resnet_model_v1.dat') if face_encoding_tracker else None
 
         Server(ModelSizeConfig, self._dyn_reconfig_callback)
 

--- a/rt_gene/src/rt_gene/extract_landmarks_method.py
+++ b/rt_gene/src/rt_gene/extract_landmarks_method.py
@@ -39,9 +39,14 @@ from rt_gene.tracker import GenericTracker, TrackedElement
 import face_alignment
 from face_alignment.detection.sfd import FaceDetector
 
-import torch
+import dlib
+
+FACE_ENCODER = dlib.face_recognition_model_v1(
+    rospkg.RosPack().get_path('rt_gene') + '/model_nets/dlib_face_recognition_resnet_model_v1.dat')
+
 
 class TrackedSubject(TrackedElement):
+
     def __init__(self, box, face, landmarks, marks):
         super(TrackedSubject, self).__init__()
         self.box = box
@@ -49,9 +54,64 @@ class TrackedSubject(TrackedElement):
         self.transformed_landmarks = landmarks
         self.marks = marks
 
+    def _align(self, desired_left_eye=(0.3, 0.3), desired_face_width=150, desired_face_height=150):
+        # extract the left and right eye (x, y)-coordinates
+        right_eye_pts = np.array([self.transformed_landmarks[0], self.transformed_landmarks[1]])
+        left_eye_pts = np.array([self.transformed_landmarks[2], self.transformed_landmarks[3]])
+
+        # compute the center of mass for each eye
+        left_eye_centre = left_eye_pts.mean(axis=0).astype("int")
+        right_eye_centre = right_eye_pts.mean(axis=0).astype("int")
+
+        # compute the angle between the eye centroids
+        d_y = right_eye_centre[1] - left_eye_centre[1]
+        d_x = right_eye_centre[0] - left_eye_centre[0]
+        angle = np.degrees(np.arctan2(d_y, d_x)) - 180
+
+        # compute the desired right eye x-coordinate based on the
+        # desired x-coordinate of the left eye
+        desired_right_eye_x = 1.0 - desired_left_eye[0]
+
+        # determine the scale of the new resulting image by taking
+        # the ratio of the distance between eyes in the *current*
+        # image to the ratio of distance between eyes in the
+        # *desired* image
+        dist = np.sqrt((d_x ** 2) + (d_y ** 2))
+        desired_dist = (desired_right_eye_x - desired_left_eye[0])
+        desired_dist *= desired_face_width
+        scale = desired_dist / dist
+
+        # compute center (x, y)-coordinates (i.e., the median point)
+        # between the two eyes in the input image
+        eyes_center = ((left_eye_centre[0] + right_eye_centre[0]) // 2,
+                       (left_eye_centre[1] + right_eye_centre[1]) // 2)
+
+        # grab the rotation matrix for rotating and scaling the face
+        rotation_matrix = cv2.getRotationMatrix2D(eyes_center, angle, scale)
+
+        # update the translation component of the matrix
+        t_x = desired_face_width * 0.5
+        t_y = desired_face_height * desired_left_eye[1]
+        rotation_matrix[0, 2] += (t_x - eyes_center[0])
+        rotation_matrix[1, 2] += (t_y - eyes_center[1])
+
+        # apply the affine transformation
+        output = cv2.warpAffine(self.face_color, rotation_matrix, (desired_face_width, desired_face_height),
+                                flags=cv2.INTER_CUBIC)
+
+        # return the aligned face
+        return output
+
     # override method
     def compute_distance(self, other_element):
-        return np.sqrt(np.sum((self.box-other_element.box)**2))
+        return np.sqrt(np.sum((self.box - other_element.box) ** 2))
+
+    # override method
+    def encode(self):
+        # get the face_color and face_chip it using the transformed_landmarks
+        face_chip = self._align()
+        encoding = FACE_ENCODER.compute_face_descriptor(face_chip)
+        return encoding
 
 
 class LandmarkMethod(object):
@@ -414,7 +474,7 @@ class LandmarkMethod(object):
                 pass
             else:
                 raise e
-    
+
     @staticmethod
     def crop_face_from_image(color_img, box):
         _bb = map(int, box)
@@ -442,8 +502,9 @@ class LandmarkMethod(object):
         for facebox, landmarks, face_image in zip(faceboxes, all_landmarks, face_images):
             np_landmarks = np.array(landmarks)
             transformed_landmarks = LandmarkMethod.transform_landmarks(np_landmarks, facebox)
-            tracked_subjects.append(TrackedSubject(np.array(facebox), face_image, transformed_landmarks, np_landmarks))
-        
+            subject = TrackedSubject(np.array(facebox), face_image, transformed_landmarks, np_landmarks)
+            tracked_subjects.append(subject)
+
         # track the new faceboxes according to the previous ones
         self.subject_tracker.track(tracked_subjects)
 

--- a/rt_gene/src/rt_gene/tracker.py
+++ b/rt_gene/src/rt_gene/tracker.py
@@ -3,7 +3,7 @@
 Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode)
 """
 import numpy as np
-import scipy
+import scipy.optimize
 
 
 class TrackedElement(object):


### PR DESCRIPTION
As per #23 

This pull request creates an "encoding" of each tracked subject only when adding the new subject. The initial insertion takes 50ms for the encoding and is then only ran again if the Hungarian tracker loses the subject and adds a new subject.

It reuses the variables already in `TrackedSubject`, namely `transformed_landmarks` to align the image rotating it facing upwards and then resizes it to 150x150 to then pass it to dlib to encode it.

There's a new param "face_encoding_tracker" that enables the tracking at init time. The default is False to keep it consistent with downstream code and thus has no runtime overhead.

I've tested this with faces from the internet along mine and it seems to work quite reliably. The speed of the networks (face detectors, landmark extractors and eye gaze estimators) are unaffected.