### PR TITLE
Publish prediction topics

### DIFF
--- a/rt_gene/CMakeLists.txt
+++ b/rt_gene/CMakeLists.txt
@@ -102,6 +102,10 @@ add_message_files(
    MSG_SubjectImagesList.msg
    MSG_Gaze.msg
    MSG_Headpose.msg
+   MSG_Landmarks.msg
+   MSG_GazeList.msg
+   MSG_HeadposeList.msg
+   MSG_LandmarksList.msg
 )
 
 # Generate added messages and services with any dependencies listed here

--- a/rt_gene/CMakeLists.txt
+++ b/rt_gene/CMakeLists.txt
@@ -100,6 +100,8 @@ add_message_files(
    FILES
    MSG_SubjectImages.msg
    MSG_SubjectImagesList.msg
+   MSG_Gaze.msg
+   MSG_Headpose.msg
 )
 
 # Generate added messages and services with any dependencies listed here

--- a/rt_gene/msg/MSG_Gaze.msg
+++ b/rt_gene/msg/MSG_Gaze.msg
@@ -1,0 +1,3 @@
+Header header
+float64 phi
+float64 theta

--- a/rt_gene/msg/MSG_Gaze.msg
+++ b/rt_gene/msg/MSG_Gaze.msg
@@ -1,3 +1,3 @@
-Header header
+string subject_id
 float64 phi
 float64 theta

--- a/rt_gene/msg/MSG_GazeList.msg
+++ b/rt_gene/msg/MSG_GazeList.msg
@@ -1,0 +1,2 @@
+Header header
+MSG_Gaze[] subjects

--- a/rt_gene/msg/MSG_Headpose.msg
+++ b/rt_gene/msg/MSG_Headpose.msg
@@ -1,0 +1,4 @@
+Header header
+float64 roll
+float64 pitch
+float64 yaw

--- a/rt_gene/msg/MSG_Headpose.msg
+++ b/rt_gene/msg/MSG_Headpose.msg
@@ -1,4 +1,7 @@
-Header header
+string subject_id
 float64 roll
 float64 pitch
 float64 yaw
+float64 x
+float64 y
+float64 z

--- a/rt_gene/msg/MSG_HeadposeList.msg
+++ b/rt_gene/msg/MSG_HeadposeList.msg
@@ -1,0 +1,2 @@
+Header header
+MSG_Headpose[] subjects

--- a/rt_gene/msg/MSG_Landmarks.msg
+++ b/rt_gene/msg/MSG_Landmarks.msg
@@ -1,0 +1,2 @@
+string subject_id
+float64[] landmarks

--- a/rt_gene/msg/MSG_LandmarksList.msg
+++ b/rt_gene/msg/MSG_LandmarksList.msg
@@ -1,0 +1,2 @@
+Header header
+MSG_Landmarks[] subjects

--- a/rt_gene/scripts/estimate_gaze_standalone.py
+++ b/rt_gene/scripts/estimate_gaze_standalone.py
@@ -34,7 +34,7 @@ def load_camera_calibration(calibration_file):
 
 def extract_eye_image_patches(subjects):
     for subject in subjects:
-        le_c, re_c, le_bb, re_bb = subject.get_eye_image_from_landmarks(subject.transformed_landmarks, subject.face_color, landmark_estimator.eye_image_size)
+        le_c, re_c, le_bb, re_bb = subject.get_eye_image_from_landmarks(subject.transformed_eye_landmarks, subject.face_color, landmark_estimator.eye_image_size)
         subject.left_eye_color = le_c
         subject.right_eye_color = re_c
         subject.left_eye_bb = le_bb

--- a/rt_gene/scripts/estimate_gaze_standalone.py
+++ b/rt_gene/scripts/estimate_gaze_standalone.py
@@ -61,7 +61,7 @@ def estimate_gaze(base_name, color_img, dist_coefficients, camera_matrix):
             continue
 
         success, rotation_vector, _ = cv2.solvePnP(landmark_estimator.model_points,
-                                                   subject.marks.reshape(len(subject.marks), 1, 2),
+                                                   subject.landmarks.reshape(len(subject.marks), 1, 2),
                                                    cameraMatrix=camera_matrix,
                                                    distCoeffs=dist_coefficients, flags=cv2.SOLVEPNP_DLS)
 

--- a/rt_gene/scripts/extract_landmarks_node.py
+++ b/rt_gene/scripts/extract_landmarks_node.py
@@ -27,7 +27,7 @@ import rt_gene.gaze_tools as gaze_tools
 
 from rt_gene.kalman_stabilizer import Stabilizer
 
-from rt_gene.msg import MSG_SubjectImagesList
+from rt_gene.msg import MSG_SubjectImagesList, MSG_Headpose
 from rt_gene.cfg import ModelSizeConfig
 from rt_gene.subject_ros_bridge import SubjectListBridge
 from rt_gene.tracker_face_encoding import FaceEncodingTracker
@@ -55,6 +55,8 @@ class LandmarkMethodROS(LandmarkMethodBase):
         self.visualise_headpose = rospy.get_param("~visualise_headpose", default=True)
 
         self.pose_stabilizers = {}  # Introduce scalar stabilizers for pose.
+
+        self.headpose_publishers = {}
 
         try:
             if img_proc is None:
@@ -198,6 +200,7 @@ class LandmarkMethodROS(LandmarkMethodBase):
         self.subject_pub.publish(subject_list_message)
 
     def publish_pose(self, timestamp, nose_center_3d_tf, head_rpy, subject_id):
+
         t = TransformStamped()
         t.header.frame_id = self.camera_frame
         t.header.stamp = timestamp
@@ -221,6 +224,16 @@ class LandmarkMethodROS(LandmarkMethodBase):
                 raise exc
 
         self.tf2_buffer.set_transform(t, 'extract_landmarks')
+
+        headpose = MSG_Headpose()
+        headpose.header.stamp = timestamp
+        headpose.header.frame_id = '0'
+        headpose.roll = head_rpy[0]
+        headpose.pitch = head_rpy[1]
+        headpose.yaw = head_rpy[2]
+        if str(subject_id) not in self.headpose_publishers:
+            self.headpose_publishers[str(subject_id)] = rospy.Publisher('/subjects/head_pose'+str(subject_id), MSG_Headpose, queue_size=3)
+        self.headpose_publishers[str(subject_id)].publish(headpose)
 
     def update_subject_tracker(self, color_img):
         faceboxes = self.get_face_bb(color_img)

--- a/rt_gene/scripts/extract_landmarks_node.py
+++ b/rt_gene/scripts/extract_landmarks_node.py
@@ -27,7 +27,10 @@ import rt_gene.gaze_tools as gaze_tools
 
 from rt_gene.kalman_stabilizer import Stabilizer
 
-from rt_gene.msg import MSG_SubjectImagesList, MSG_Headpose
+from rt_gene.msg import MSG_SubjectImagesList
+from rt_gene.msg import MSG_Headpose, MSG_HeadposeList
+from rt_gene.msg import MSG_Landmarks, MSG_LandmarksList
+
 from rt_gene.cfg import ModelSizeConfig
 from rt_gene.subject_ros_bridge import SubjectListBridge
 from rt_gene.tracker_face_encoding import FaceEncodingTracker
@@ -56,8 +59,6 @@ class LandmarkMethodROS(LandmarkMethodBase):
 
         self.pose_stabilizers = {}  # Introduce scalar stabilizers for pose.
 
-        self.headpose_publishers = {}
-
         try:
             if img_proc is None:
                 tqdm.write("Wait for camera message")
@@ -77,6 +78,8 @@ class LandmarkMethodROS(LandmarkMethodBase):
 
         # multiple person images publication
         self.subject_pub = rospy.Publisher("/subjects/images", MSG_SubjectImagesList, queue_size=3)
+        self.headpose_publisher = rospy.Publisher("/subjects/headpose", MSG_HeadposeList, queue_size=3)
+        self.landmark_publisher = rospy.Publisher("/subjects/landmarks", MSG_LandmarksList, queue_size=3)
         # multiple person faces publication for visualisation
         self.subject_faces_pub = rospy.Publisher("/subjects/faces", Image, queue_size=3)
 
@@ -112,10 +115,12 @@ class LandmarkMethodROS(LandmarkMethodBase):
             if subject_id not in self.pose_stabilizers:
                 self.pose_stabilizers[subject_id] = [Stabilizer(state_num=2, measure_num=1, cov_process=0.1, cov_measure=0.1) for _ in range(6)]
 
-            success, head_rpy, translation_vector = self.get_head_pose(subject.marks, subject_id)
+            success, head_rpy, translation_vector = self.get_head_pose(subject.landmarks, subject_id)
 
             if success:
                 # Publish all the data
+                subject.head_rotation = head_rpy
+                subject.head_translation = translation_vector
                 self.publish_pose(timestamp, translation_vector, head_rpy, subject_id)
 
                 if self.visualise_headpose:
@@ -194,13 +199,44 @@ class LandmarkMethodROS(LandmarkMethodBase):
 
     def publish_subject_list(self, timestamp, subjects):
         assert (subjects is not None)
-
         subject_list_message = self.__subject_bridge.images_to_msg(subjects, timestamp)
-
         self.subject_pub.publish(subject_list_message)
 
-    def publish_pose(self, timestamp, nose_center_3d_tf, head_rpy, subject_id):
+        landmark_msg_list = MSG_LandmarksList()
+        landmark_msg_list.header.stamp = timestamp
+        landmark_msg_list.header.frame_id = '0'
 
+        headpose_msg_list = MSG_HeadposeList()
+        headpose_msg_list.header.stamp = timestamp
+        headpose_msg_list.header.frame_id = '0'
+
+        for subject_id, s in subjects.items():
+            try:
+                landmark_msg = MSG_Landmarks()
+                landmark_msg.subject_id = str(subject_id)
+                landmark_msg.landmarks = s.landmarks.flatten()
+                landmark_msg_list.subjects.append(landmark_msg)
+            except AttributeError:
+                # we haven't assigned landmarks to the subject "s" yet...ignore this subject for the time being
+                pass
+
+            try:
+                headpose_msg = MSG_Headpose()
+                headpose_msg.roll = s.head_rotation[0]
+                headpose_msg.pitch = s.head_rotation[1]
+                headpose_msg.yaw = s.head_rotation[2]
+                headpose_msg.x = s.head_translation[0]
+                headpose_msg.y = s.head_translation[1]
+                headpose_msg.z = s.head_translation[2]
+                headpose_msg_list.subjects.append(headpose_msg)
+            except AttributeError:
+                # we haven't assigned landmarks to the subject "s" yet...ignore this subject for the time being
+                pass
+
+        self.landmark_publisher.publish(landmark_msg_list)
+        self.headpose_publisher.publish(headpose_msg_list)
+
+    def publish_pose(self, timestamp, nose_center_3d_tf, head_rpy, subject_id):
         t = TransformStamped()
         t.header.frame_id = self.camera_frame
         t.header.stamp = timestamp
@@ -224,16 +260,6 @@ class LandmarkMethodROS(LandmarkMethodBase):
                 raise exc
 
         self.tf2_buffer.set_transform(t, 'extract_landmarks')
-
-        headpose = MSG_Headpose()
-        headpose.header.stamp = timestamp
-        headpose.header.frame_id = '0'
-        headpose.roll = head_rpy[0]
-        headpose.pitch = head_rpy[1]
-        headpose.yaw = head_rpy[2]
-        if str(subject_id) not in self.headpose_publishers:
-            self.headpose_publishers[str(subject_id)] = rospy.Publisher('/subjects/head_pose'+str(subject_id), MSG_Headpose, queue_size=3)
-        self.headpose_publishers[str(subject_id)].publish(headpose)
 
     def update_subject_tracker(self, color_img):
         faceboxes = self.get_face_bb(color_img)

--- a/rt_gene/src/rt_gene/tracker_face_encoding.py
+++ b/rt_gene/src/rt_gene/tracker_face_encoding.py
@@ -27,8 +27,8 @@ class FaceEncodingTracker(GenericTracker):
     @staticmethod
     def __align_tracked_subject(tracked_subject, desired_left_eye=(0.3, 0.3), desired_face_width=150, desired_face_height=150):
         # extract the left and right eye (x, y)-coordinates
-        right_eye_pts = np.array([tracked_subject.transformed_landmarks[0], tracked_subject.transformed_landmarks[1]])
-        left_eye_pts = np.array([tracked_subject.transformed_landmarks[2], tracked_subject.transformed_landmarks[3]])
+        right_eye_pts = np.array([tracked_subject.transformed_eye_landmarks[0], tracked_subject.transformed_eye_landmarks[1]])
+        left_eye_pts = np.array([tracked_subject.transformed_eye_landmarks[2], tracked_subject.transformed_eye_landmarks[3]])
 
         # compute the center of mass for each eye
         left_eye_centre = left_eye_pts.mean(axis=0).astype("int")
@@ -74,7 +74,7 @@ class FaceEncodingTracker(GenericTracker):
         return output
 
     def __encode_subject(self, tracked_element):
-        # get the face_color and face_chip it using the transformed_landmarks
+        # get the face_color and face_chip it using the transformed_eye_landmarks
         face_chip = self.__align_tracked_subject(tracked_element)
         encoding = self.FACE_ENCODER.compute_face_descriptor(face_chip)
         return encoding


### PR DESCRIPTION
This branch adds the ability to extract various parts of the gaze estimation pathway and publishes them as ROS messages, namely:
- `Gaze/GazeList.msg`
- `Headpose/HeadposeList.msg`
- `Landmarks/LandmarksList.msg`

The message types are kept inline with the previous `SubjectImages/SubjectImagesList.msg` type to maintain current standards of message publishing.

I also modified "transformed_landmarks" variable name to reflect that it's actually just the eye landmarks.
There is very little overhead that I can measure.

Let me know what you think.