### PR TITLE
Face align (rebased)

### DIFF
--- a/rt_gene/README.md
+++ b/rt_gene/README.md
@@ -95,4 +95,5 @@ Follow the instructions for estimating gaze above, and run in addition `roslaunc
 - 3DDFA face alignment in [./src/rt_gene/ThreeDDFA](./src/rt_gene/ThreeDDFA); [MIT License](https://opensource.org/licenses/MIT), [Link to GitHub](https://github.com/cleardusk/3DDFA), [Link to paper](https://arxiv.org/abs/1804.01005)
 - S3FD face detector in [./src/rt_gene/SFD](./src/rt_gene/SFD); [BSD 3-clause](https://opensource.org/licenses/BSD-3-Clause), [Link to GitHub](https://github.com/1adrianb/face-alignment)
 - Kalman filter in [./src/rt_gene/kalman_stabilizer.py](./src/rt_gene/kalman_stabilizer.py): [MIT License](https://opensource.org/licenses/MIT), [Link to GitHub](https://github.com/yinguobing/head-pose-estimation)
+- Face alignment [./src/rt_gene/tracker_generic.py](./src/rt_gene/tracker_generic.py): [Link to website](https://www.pyimagesearch.com/2017/05/22/face-alignment-with-opencv-and-python/)
 

--- a/rt_gene/src/rt_gene/extract_landmarks_method_base.py
+++ b/rt_gene/src/rt_gene/extract_landmarks_method_base.py
@@ -1,7 +1,5 @@
 # Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode)
 
-import time
-
 import cv2
 import numpy as np
 import torch
@@ -108,14 +106,6 @@ class LandmarkMethodBase(object):
         cv2.line(output_image, (int(center_x), int(center_y)), (int(endpoint_x), int(endpoint_y)), (0, 0, 255), 3)
         return output_image
 
-    @staticmethod
-    def transform_landmarks(landmarks, box):
-        eye_indices = np.array([36, 39, 42, 45])
-        transformed_landmarks = landmarks[eye_indices]
-        transformed_landmarks[:, 0] -= box[0]
-        transformed_landmarks[:, 1] -= box[1]
-        return transformed_landmarks
-
     def ddfa_forward_pass(self, color_img, roi_box_list):
         img_step = [crop_img(color_img, roi_box) for roi_box in roi_box_list]
         img_step = [cv2.resize(img, dsize=(120, 120), interpolation=cv2.INTER_LINEAR) for img in img_step]
@@ -136,6 +126,5 @@ class LandmarkMethodBase(object):
 
         for pts68, face_image, facebox in zip(pts68_list, face_images, faceboxes):
             np_landmarks = np.array((pts68[0], pts68[1])).T
-            transformed_landmarks = self.transform_landmarks(np_landmarks, facebox)
-            subjects.append(TrackedSubject(np.array(facebox), face_image, transformed_landmarks, np_landmarks))
+            subjects.append(TrackedSubject(np.array(facebox), face_image, np_landmarks))
         return subjects

--- a/rt_gene/src/rt_gene/gaze_tools.py
+++ b/rt_gene/src/rt_gene/gaze_tools.py
@@ -6,6 +6,7 @@ Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 Interna
 from __future__ import print_function, division, absolute_import
 
 import math
+
 import numpy as np
 
 
@@ -140,3 +141,11 @@ def accuracy_angle(y_true, y_pred):
     angle_value = (pred_x * true_x + pred_y * true_y + pred_z * true_z) / (true_norm * pred_norm)
     tf.clip_by_value(angle_value, -0.9999999999, 0.999999999)
     return (tf.acos(angle_value) * 180.0) / np.pi
+
+
+def get_normalised_eye_landmarks(landmarks, box):
+    eye_indices = np.array([36, 39, 42, 45])
+    transformed_landmarks = landmarks[eye_indices]
+    transformed_landmarks[:, 0] -= box[0]
+    transformed_landmarks[:, 1] -= box[1]
+    return transformed_landmarks

--- a/rt_gene/src/rt_gene/tracker_generic.py
+++ b/rt_gene/src/rt_gene/tracker_generic.py
@@ -111,9 +111,9 @@ class GenericTracker(object):
 
     @staticmethod
     def align_face_to_eyes(face_img, right_eye_center, left_eye_center, face_width=None, face_height=None):
-        # modified lightly from https://www.pyimagesearch.com/2017/05/22/face-alignment-with-opencv-and-python/
+        # modified from https://www.pyimagesearch.com/2017/05/22/face-alignment-with-opencv-and-python/
         desired_left_eye = (0.35, 0.35)
-        desired_face_width = face_height if face_width is not None else face_img.shape[1]
+        desired_face_width = face_width if face_width is not None else face_img.shape[1]
         desired_face_height = face_height if face_height is not None else face_img.shape[0]
         # compute the angle between the eye centroids
         d_y = right_eye_center[1] - left_eye_center[1]

--- a/rt_gene_standalone/estimate_gaze_standalone.py
+++ b/rt_gene_standalone/estimate_gaze_standalone.py
@@ -34,11 +34,9 @@ def load_camera_calibration(calibration_file):
 
 def extract_eye_image_patches(subjects):
     for subject in subjects:
-        le_c, re_c, le_bb, re_bb = subject.get_eye_image_from_landmarks(subject.transformed_eye_landmarks, subject.face_color, landmark_estimator.eye_image_size)
+        le_c, re_c, _, _ = subject.get_eye_image_from_landmarks(subject, landmark_estimator.eye_image_size)
         subject.left_eye_color = le_c
         subject.right_eye_color = re_c
-        subject.left_eye_bb = le_bb
-        subject.right_eye_bb = re_bb
 
 
 def estimate_gaze(base_name, color_img, dist_coefficients, camera_matrix):


### PR DESCRIPTION
See #66 - this version is based on the master rather than pytorch branch:

Following the change from the previous face detector that would automatically axis-align the face to one that doesn't, the eye patches have become inconsistent as the roll of the head changes significantly from zero.

This branch corrects that by affine transforming the face image based on eye landmarks to better extract the eye patches.

It's done at minimal cost; the standalone and the ros nodes continue to work as expected