### PR TITLE
Make estimate_gaze_standalone.py work without cuda

### DIFF
--- a/rt_gene/src/rt_gene/extract_landmarks_method_base.py
+++ b/rt_gene/src/rt_gene/extract_landmarks_method_base.py
@@ -26,13 +26,13 @@ class LandmarkMethodBase(object):
 
         tqdm.write("Using device {} for face detection.".format(device_id_facedetection))
 
+        self.use_cuda = 'cuda' in device_id_facedetection
         self.face_net = SFDDetector(device=device_id_facedetection, path_to_detector=checkpoint_path_face)
         self.facial_landmark_nn = self.load_face_landmark_model(checkpoint_path_landmark)
 
         self.model_points = self.get_full_model_points(model_points_file)
 
-    @staticmethod
-    def load_face_landmark_model(checkpoint_fp=None):
+    def load_face_landmark_model(self, checkpoint_fp=None):
         import rt_gene.ThreeDDFA.mobilenet_v1 as mobilenet_v1
         if checkpoint_fp is None:
             import rospkg
@@ -48,7 +48,8 @@ class LandmarkMethodBase(object):
             model_dict[k.replace('module.', '')] = checkpoint[k]
         model.load_state_dict(model_dict)
         cudnn.benchmark = True
-        model = model.cuda()
+        if self.use_cuda:
+            model = model.cuda()
         model.eval()
         return model
 
@@ -111,7 +112,8 @@ class LandmarkMethodBase(object):
         img_step = [cv2.resize(img, dsize=(120, 120), interpolation=cv2.INTER_LINEAR) for img in img_step]
         _input = torch.cat([facial_landmark_transform(img).unsqueeze(0) for img in img_step], 0)
         with torch.no_grad():
-            _input = _input.cuda()
+            if self.use_cuda:
+                _input = _input.cuda()
             param = self.facial_landmark_nn(_input).cpu().numpy().astype(np.float32)
 
         return [predict_68pts(p.flatten(), roi_box) for p, roi_box in zip(param, roi_box_list)]

--- a/rt_gene_standalone/estimate_gaze_standalone.py
+++ b/rt_gene_standalone/estimate_gaze_standalone.py
@@ -145,6 +145,7 @@ if __name__ == '__main__':
     parser.add_argument('--output_path', type=str, default=os.path.join(script_path, './samples_gaze/out'), help='Output directory for head pose and gaze images')
     parser.add_argument('--models', nargs='+', type=str, default=[os.path.join(script_path, '../rt_gene/model_nets/Model_allsubjects1.h5')],
                         help='List of gaze estimators')
+    parser.add_argument('--device-id-facedetection', dest="device_id_facedetection", type=str, default='cuda:0', help='Pytorch device id. Set to "cpu:0" to disable cuda')
 
     parser.set_defaults(vis_gaze=True)
     parser.set_defaults(save_gaze=True)
@@ -168,7 +169,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     tqdm.write('Loading networks')
-    landmark_estimator = LandmarkMethodBase(device_id_facedetection="cuda:0",
+    landmark_estimator = LandmarkMethodBase(device_id_facedetection=args.device_id_facedetection,
                                             checkpoint_path_face=os.path.join(script_path, "../rt_gene/model_nets/SFD/s3fd_facedetector.pth"),
                                             checkpoint_path_landmark=os.path.join(script_path, "../rt_gene/model_nets/phase1_wpdc_vdc.pth.tar"),
                                             model_points_file=os.path.join(script_path, "../rt_gene/model_nets/face_model_68.txt"))


### PR DESCRIPTION
My home dev machine is a 5 year old macbook, and I was curious to try out your project (which I found on paperswithcode). After a little bit of patching, I managed to get it to work without cuda, and it works really well.

It's a bit too slow to process 1080p video frames (unsurprisingly), but if I restrict myself to only looking at keyframes (~every 2-4 seconds), and I extract face chips using opencv+dlib (which I'm already doing for another part of my project) then it is fast enough to iterate on.

This is the patch I needed to make it work without cuda.

Now that I know that I have the standalone example working, I will try integrating it into my project, and see if anything else needs tweaking.