### PR TITLE
ensured consistent frame_ids across RT-GENE/BENE

### DIFF
--- a/rt_bene_standalone/estimate_blink_standalone.py
+++ b/rt_bene_standalone/estimate_blink_standalone.py
@@ -86,7 +86,7 @@ class BlinkEstimatorFolderPair(BlinkEstimatorStandalone):
                 pair_img = np.concatenate((right_image, left_image), axis=1)
                 viz_img = self.overlay_prediction_over_img(pair_img, is_blinking)
                 cv2.imshow('folder images visualisation', viz_img)
-                cv2.waitKey(1)
+                cv2.waitKey(0)
         for left_image, right_image, p, is_blinking in zip(left_image_paths, right_image_paths, probs, blinks):
             print("Blink: %s (p=%.3f) for image pair: %20s %20s" % ("Yes" if is_blinking else "No ", p,
                                                                     os.path.basename(left_image), os.path.basename(right_image)))

--- a/rt_gene/scripts/estimate_blink.py
+++ b/rt_gene/scripts/estimate_blink.py
@@ -82,7 +82,7 @@ class BlinkEstimatorNode(BlinkEstimatorBase):
 
     def publish_msg(self, header, subjects, probabilities):
         blink_msg_list = MSG_BlinkList()
-        blink_msg_list.header.stamp = header
+        blink_msg_list.header = header
         for subject_id, p in zip(subjects.keys(), probabilities):
             blink_msg = MSG_Blink()
             blink_msg.subject_id = str(subject_id)

--- a/rt_gene/scripts/estimate_blink.py
+++ b/rt_gene/scripts/estimate_blink.py
@@ -57,7 +57,7 @@ class BlinkEstimatorNode(BlinkEstimatorBase):
 
         probs, _ = self.predict(left_eyes, right_eyes)
 
-        self.publish_msg(msg.header.stamp, subjects, probs)
+        self.publish_msg(msg.header, subjects, probs)
 
         if self.viz:
             blink_image_list = []
@@ -80,10 +80,9 @@ class BlinkEstimatorNode(BlinkEstimatorBase):
             '\033[2K\033[1;32mTime now: {:.2f} message color: {:.2f} latency: {:.2f}s for {} subject(s) {:.0f}Hz\033[0m'.format(
                 (_now.to_sec()), timestamp.to_sec(), np.mean(self._latency_deque), len(subjects), np.mean(self._freq_deque)), end="\r")
 
-    def publish_msg(self, timestamp, subjects, probabilities):
+    def publish_msg(self, header, subjects, probabilities):
         blink_msg_list = MSG_BlinkList()
-        blink_msg_list.header.stamp = timestamp
-        blink_msg_list.header.frame_id = '0'
+        blink_msg_list.header.stamp = header
         for subject_id, p in zip(subjects.keys(), probabilities):
             blink_msg = MSG_Blink()
             blink_msg.subject_id = str(subject_id)

--- a/rt_gene/scripts/estimate_gaze.py
+++ b/rt_gene/scripts/estimate_gaze.py
@@ -107,7 +107,7 @@ class GazeEstimatorROS(object):
                                                               inference_input_right_list=input_r_list,
                                                               inference_headpose_list=input_head_list)
         subject_subset = dict((k, subjects_dict[k]) for k in valid_subject_list if k in subjects_dict)
-        self.publish_gaze_msg(timestamp, subject_subset, gaze_est.tolist())
+        self.publish_gaze_msg(subject_image_list.header, subject_subset, gaze_est.tolist())
 
         subjects_gaze_img_list = []
         for subject_id, gaze in zip(valid_subject_list, gaze_est.tolist()):
@@ -135,10 +135,9 @@ class GazeEstimatorROS(object):
             '\033[2K\033[1;32mTime now: {:.2f} message color: {:.2f} latency: {:.2f}s for {} subject(s) {:.0f}Hz\033[0m'.format(
                 (_now.to_sec()), timestamp.to_sec(), np.mean(self._latency_deque), len(valid_subject_list), np.mean(self._freq_deque)), end="\r")
 
-    def publish_gaze_msg(self, timestamp, subjects, gazes):
+    def publish_gaze_msg(self, header, subjects, gazes):
         gaze_msg_list = MSG_GazeList()
-        gaze_msg_list.header.stamp = timestamp
-        gaze_msg_list.header.frame_id = '0'
+        gaze_msg_list.header = header
         for subjects_id, gaze in zip(subjects.keys(), gazes):
             gaze_msg = MSG_Gaze()
             gaze_msg.subject_id = subjects_id


### PR DESCRIPTION
At the moment the frame_id of the MSG_GazeList and MSG_BlinkList are set to "0". This patch fixes the publishing to maintain consistency

Also, fixed a small waitKey bug where the RTBENE standalone visualisation would disappear quickly